### PR TITLE
Find only the opened top components as candidates for closing

### DIFF
--- a/src/de/markiew/netbeans/plugin/actions/closedocuments/DocumentManager.java
+++ b/src/de/markiew/netbeans/plugin/actions/closedocuments/DocumentManager.java
@@ -138,7 +138,7 @@ public final class DocumentManager {
         final WindowManager wm = WindowManager.getDefault();
         for (Mode mode : wm.getModes()) {
             if (wm.isEditorMode(mode)) {
-                result.addAll(Arrays.asList(mode.getTopComponents()));
+                result.addAll(Arrays.asList(wm.getOpenedTopComponents(mode)));
             }
         }
         return result;


### PR DESCRIPTION
On my machine, this meant orders of magnitude speedup in finding the
opened windows, and because there were fewer closing them improved in
speed as well.